### PR TITLE
Fixed all tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,17 +18,19 @@
         }
     ],
     "require": {
-        "yiisoft/yii-core": "^3.0",
+        "yiisoft/yii-core": "^3.0@dev",
         "psr/http-message": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.3",
-        "yiisoft/yii-core": "dev-master",
-        "yiisoft/yii-console": "dev-master",
-        "yiisoft/di": "dev-master",
-        "yiisoft/log": "dev-master",
-        "yiisoft/cache": "dev-master",
-        "hiqdev/composer-config-plugin": "dev-master"
+        "yiisoft/yii-core": "^3.0@dev",
+        "yiisoft/yii-console": "^3.0@dev",
+        "yiisoft/yii-web": "^3.0@dev",
+        "yiisoft/view": "^3.0@dev",
+        "yiisoft/di": "^3.0@dev",
+        "yiisoft/log": "^3.0@dev",
+        "yiisoft/cache": "^3.0@dev",
+        "hiqdev/composer-config-plugin": "^1.0@dev"
     },
     "autoload": {
         "psr-4": {"yii\\httpclient\\": "src"}

--- a/src/Client.php
+++ b/src/Client.php
@@ -24,14 +24,6 @@ use yii\http\MemoryStream;
 class Client extends Component
 {
     /**
-     * @event RequestEvent an event raised right before sending request.
-     */
-    const EVENT_BEFORE_SEND = 'beforeSend';
-    /**
-     * @event RequestEvent an event raised right after request has been sent.
-     */
-    const EVENT_AFTER_SEND = 'afterSend';
-    /**
      * JSON format
      */
     const FORMAT_JSON = 'json';
@@ -86,6 +78,14 @@ class Client extends Component
      */
     private $_transport = StreamTransport::class;
 
+    /**
+     * Constructor
+     * @param Transport|array|string|callable HTTP message transport.
+     */
+    public function __construct($transport = null)
+    {
+        if($transport !== null) $this->_transport = $transport;
+    }
 
     /**
      * Sets the HTTP message transport. It can be specified in one of the following forms:
@@ -378,9 +378,7 @@ class Client extends Component
      */
     public function beforeSend($request)
     {
-        $event = new RequestEvent();
-        $event->request = $request;
-        $this->trigger(self::EVENT_BEFORE_SEND, $event);
+        $this->trigger(ClientEvent::beforeSend($request));
     }
 
     /**
@@ -392,10 +390,7 @@ class Client extends Component
      */
     public function afterSend($request, $response)
     {
-        $event = new RequestEvent();
-        $event->request = $request;
-        $event->response = $response;
-        $this->trigger(self::EVENT_AFTER_SEND, $event);
+        $this->trigger(ClientEvent::afterSend($request, $response));
     }
 
     /**

--- a/src/ClientEvent.php
+++ b/src/ClientEvent.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\httpclient;
+
+use yii\base\Event;
+
+/**
+ * ClientEvent represents the event parameter used for a client events.
+ *
+ * @author Fabrizio Caldarelli <fabrizio.caldarelli@gmail.com>
+ * @since 3.0.0
+ */
+class ClientEvent extends RequestEvent
+{
+    /**
+     * @event ClientEvent an event raised right before sending request.
+     */
+    const BEFORE_SEND = 'yii\httpclient\ClientEvent::BEFORE_SEND';
+
+    /**
+     * @event ClientEvent an event raised right after request has been sent.
+     */
+    const AFTER_SEND = 'yii\httpclient\ClientEvent::AFTER_SEND';
+}

--- a/src/Message.php
+++ b/src/Message.php
@@ -12,8 +12,8 @@ use yii\base\Component;
 use yii\base\ErrorHandler;
 use yii\http\Cookie;
 use yii\http\CookieCollection;
-use Yii;
 use yii\http\MessageTrait;
+use yii\helpers\Yii;
 
 /**
  * Message represents a base HTTP message.
@@ -112,7 +112,10 @@ class Message extends Component implements MessageInterface
             if (is_array($this->_cookies)) {
                 foreach ($this->_cookies as $cookie) {
                     if (!is_object($cookie)) {
-                        $cookie = new Cookie($cookie);
+                        $cookie = Yii::createObject(array_merge(
+                            $cookie, 
+                            ['__class' => Cookie::class])
+                        );
                     }
                     $cookieCollection->add($cookie);
                 }
@@ -133,7 +136,10 @@ class Message extends Component implements MessageInterface
         $cookieCollection = $this->getCookies();
         foreach ($cookies as $cookie) {
             if (!is_object($cookie)) {
-                $cookie = new Cookie($cookie);
+                $cookie = Yii::createObject(array_merge(
+                    $cookie, 
+                    ['__class' => Cookie::class])
+                );
             }
             $cookieCollection->add($cookie);
         }

--- a/src/Request.php
+++ b/src/Request.php
@@ -30,15 +30,6 @@ use yii\http\Uri;
 class Request extends Message implements RequestInterface
 {
     /**
-     * @event RequestEvent an event raised right before sending request.
-     */
-    const EVENT_BEFORE_SEND = 'beforeSend';
-    /**
-     * @event RequestEvent an event raised right after request has been sent.
-     */
-    const EVENT_AFTER_SEND = 'afterSend';
-
-    /**
      * @var string|array target URL.
      */
     private $_url;
@@ -104,7 +95,7 @@ class Request extends Message implements RequestInterface
     {
         if (!$this->_uri instanceof UriInterface) {
             if ($this->_uri === null) {
-                $uri = new Uri(['string' => $this->createFullUrl($this->getUrl())]);
+                $uri = Uri::fromString($this->createFullUrl($this->getUrl()));
             } elseif ($this->_uri instanceof \Closure) {
                 $uri = call_user_func($this->_uri, $this);
             } else {
@@ -573,9 +564,7 @@ class Request extends Message implements RequestInterface
     {
         $this->client->beforeSend($this);
 
-        $event = new RequestEvent();
-        $event->request = $this;
-        $this->trigger(self::EVENT_BEFORE_SEND, $event);
+        $this->trigger(RequestEvent::beforeSend($this));
     }
 
     /**
@@ -588,10 +577,8 @@ class Request extends Message implements RequestInterface
     {
         $this->client->afterSend($this, $response);
 
-        $event = new RequestEvent();
-        $event->request = $this;
-        $event->response = $response;
-        $this->trigger(self::EVENT_AFTER_SEND, $event);
+        $this->trigger(RequestEvent::afterSend($this, $response));
+
     }
 
     /**

--- a/src/RequestEvent.php
+++ b/src/RequestEvent.php
@@ -18,6 +18,16 @@ use yii\base\Event;
 class RequestEvent extends Event
 {
     /**
+     * @event RequestEvent an event raised right before sending request.
+     */
+    const BEFORE_SEND = 'yii\httpclient\RequestEvent::BEFORE_SEND';
+
+    /**
+     * @event RequestEvent an event raised right after request has been sent.
+     */
+    const AFTER_SEND = 'yii\httpclient\RequestEvent::AFTER_SEND';
+
+    /**
      * @var Request related HTTP request instance.
      */
     public $request;
@@ -26,4 +36,26 @@ class RequestEvent extends Event
      * This field will be filled only in case some response is already received, e.g. after request is sent.
      */
     public $response;
+
+    /**
+     * @param string $name event name
+     * @param Request related HTTP request instance.
+     * @param Response|null related HTTP response.
+     */
+    public function __construct(string $name, Request $request, Response $response = null)
+    {
+        parent::__construct($name);
+        $this->request = $request;
+        $this->response = $response;
+    }    
+
+    public static function beforeSend($request) : self
+    {
+        return new static(static::BEFORE_SEND, $request);        
+    }
+
+    public static function afterSend($request, $response) : self
+    {
+        return new static(static::AFTER_SEND, $request, $response);        
+    }
 }

--- a/src/UrlEncodedFormatter.php
+++ b/src/UrlEncodedFormatter.php
@@ -60,7 +60,7 @@ class UrlEncodedFormatter extends BaseObject implements FormatterInterface
             return $request;
         }
 
-        $charset = $this->charset ?? Yii::getApp()->charset;
+        $charset = $this->charset ?? 'UTF-8';
         $request->setHeader('Content-Type', 'application/x-www-form-urlencoded; charset=' . $charset);
 
         if (isset($content)) {

--- a/src/XmlFormatter.php
+++ b/src/XmlFormatter.php
@@ -60,7 +60,7 @@ class XmlFormatter extends BaseObject implements FormatterInterface
     public function format(Request $request)
     {
         $contentType = $this->contentType;
-        $charset = $this->encoding ?? Yii::getApp()->charset;
+        $charset = $this->encoding ?? 'UTF-8';
         if (stripos($contentType, 'charset') === false) {
             $contentType .= '; charset=' . $charset;
         }

--- a/tests/unit/CurlTransportTest.php
+++ b/tests/unit/CurlTransportTest.php
@@ -44,7 +44,7 @@ class CurlTransportTest extends TransportTestCase
             'sslLocalPk' => '/path/to/client.key',
             'sslPassphrase' => 'passphrase of client.crt',
         ];
-        $contextOptions = $this->invoke($transport, 'composeCurlOptions', [$options]);
+        $contextOptions = $this->invokeMethod($transport, 'composeCurlOptions', [$options]);
 
         $expectedContextOptions = [
             CURLOPT_HTTP_VERSION => $options['protocolVersion'],

--- a/tests/unit/RequestTest.php
+++ b/tests/unit/RequestTest.php
@@ -5,6 +5,7 @@ namespace yii\httpclient\tests\unit;
 use yii\http\MemoryStream;
 use yii\httpclient\Client;
 use yii\httpclient\Request;
+use yii\helpers\Yii;
 
 class RequestTest extends \yii\tests\TestCase
 {
@@ -140,7 +141,8 @@ class RequestTest extends \yii\tests\TestCase
      */
     public function testFormatData()
     {
-        $request = new Request([
+        $request = Yii::createObject([
+            '__class' => Request::class,
             'client' => new Client(),
             'format' => Client::FORMAT_URLENCODED,
             'method' => 'POST',
@@ -159,7 +161,8 @@ class RequestTest extends \yii\tests\TestCase
      */
     public function testToString()
     {
-        $request = new Request([
+        $request = Yii::createObject([
+            '__class' => Request::class,
             'client' => new Client(),
             'format' => Client::FORMAT_URLENCODED,
             'method' => 'POST',
@@ -180,7 +183,8 @@ EOL;
         $this->assertEquals($expectedResult, $request->toString());
 
         // @see https://github.com/yiisoft/yii2-httpclient/issues/70
-        $request = new Request([
+        $request = Yii::createObject([
+            '__class' => Request::class,
             'client' => new Client(),
             'format' => Client::FORMAT_URLENCODED,
             'method' => 'POST',
@@ -256,7 +260,10 @@ EOL;
     {
         $client = new Client();
         $client->baseUrl = $baseUrl;
-        $request = new Request(['client' => $client]);
+        $request = Yii::createObject([
+            '__class' => Request::class,
+            'client' => $client
+        ]);        
 
         $request->setUrl($url);
         $this->assertEquals($expectedFullUrl, $request->getUri()->__toString());
@@ -267,7 +274,8 @@ EOL;
      */
     public function testReuse()
     {
-        $request = new Request([
+        $request = Yii::createObject([
+            '__class' => Request::class,
             'client' => new Client(),
             'format' => Client::FORMAT_URLENCODED,
             'method' => 'POST',
@@ -303,10 +311,12 @@ EOL;
 
     public function testMultiPartRequest()
     {
-        $request = new Request([
-            'client' => new Client([
+        $request = Yii::createObject([
+            '__class' => Request::class,
+            'client' => [
+                '__class' => Client::class,
                 'baseUrl' => '/api'
-            ]),
+            ],
             'method' => 'POST',
         ]);
 
@@ -380,10 +390,12 @@ PART2
      */
     public function testAddBodyPartAsStream()
     {
-        $request = new Request([
-            'client' => new Client([
+        $request = Yii::createObject([
+            '__class' => Request::class,
+            'client' => [
+                '__class' => Client::class,
                 'baseUrl' => '/api'
-            ]),
+            ],
             'method' => 'POST',
         ]);
 
@@ -406,8 +418,10 @@ PART2
      */
     public function testGetParamsReuse()
     {
-        $request = new Request([
-            'client' => new Client([
+        $request = Yii::createObject([
+            '__class' => Request::class,
+            'client' => Yii::createObject([
+                '__class' => Client::class,
                 'baseUrl' => 'http://php.net',
             ]),
             'format' => Client::FORMAT_URLENCODED,

--- a/tests/unit/ResponseTest.php
+++ b/tests/unit/ResponseTest.php
@@ -5,6 +5,7 @@ namespace yii\httpclient\tests\unit;
 use yii\httpclient\Client;
 use yii\httpclient\Response;
 use yii\http\Cookie;
+use yii\helpers\Yii;
 
 class ResponseTest extends \yii\tests\TestCase
 {
@@ -101,7 +102,8 @@ class ResponseTest extends \yii\tests\TestCase
 
     public function testParseBody()
     {
-        $response = new Response([
+        $response = Yii::createObject([
+            '__class' => Response::class,
             'client' => new Client(),
             'format' => Client::FORMAT_URLENCODED,
         ]);

--- a/tests/unit/StreamTransportTest.php
+++ b/tests/unit/StreamTransportTest.php
@@ -47,7 +47,7 @@ class StreamTransportTest extends TransportTestCase
             'sslLocalPk' => '/path/to/client.key',
             'sslPassphrase' => 'passphrase of client.crt',
         ];
-        $contextOptions = $this->invoke($transport, 'composeContextOptions', [$options]);
+        $contextOptions = $this->invokeMethod($transport, 'composeContextOptions', [$options]);
 
         $expectedContextOptions = [
             'http' => [

--- a/tests/unit/TransportTestCase.php
+++ b/tests/unit/TransportTestCase.php
@@ -7,6 +7,7 @@ use yii\httpclient\Client;
 use yii\httpclient\Request;
 use yii\httpclient\RequestEvent;
 use yii\httpclient\Response;
+use yii\httpclient\ClientEvent;
 
 /**
  * This is the base class for HTTP message transport unit tests.
@@ -28,7 +29,7 @@ abstract class TransportTestCase extends \yii\tests\TestCase
      */
     protected function createClient()
     {
-        return new Client(['transport' => $this->transport()]);
+        return new Client($this->transport());
     }
 
     public function testSend()
@@ -148,12 +149,12 @@ abstract class TransportTestCase extends \yii\tests\TestCase
             ->setUrl('docs.php');
 
         $beforeSendEvent = null;
-        $request->on(Request::EVENT_BEFORE_SEND, function(RequestEvent $event) use (&$beforeSendEvent) {
+        $request->on(RequestEvent::BEFORE_SEND, function(RequestEvent $event) use (&$beforeSendEvent) {
             $beforeSendEvent = $event;
         });
 
         $afterSendEvent = null;
-        $request->on(Request::EVENT_AFTER_SEND, function(RequestEvent $event) use (&$afterSendEvent) {
+        $request->on(RequestEvent::AFTER_SEND, function(RequestEvent $event) use (&$afterSendEvent) {
             $afterSendEvent = $event;
         });
 
@@ -181,12 +182,12 @@ abstract class TransportTestCase extends \yii\tests\TestCase
             ->setUrl('docs.php');
 
         $beforeSendEvent = null;
-        $client->on(Client::EVENT_BEFORE_SEND, function(RequestEvent $event) use (&$beforeSendEvent) {
+        $client->on(ClientEvent::BEFORE_SEND, function(RequestEvent $event) use (&$beforeSendEvent) {
             $beforeSendEvent = $event;
         });
 
         $afterSendEvent = null;
-        $client->on(Client::EVENT_AFTER_SEND, function(RequestEvent $event) use (&$afterSendEvent) {
+        $client->on(ClientEvent::AFTER_SEND, function(RequestEvent $event) use (&$afterSendEvent) {
             $afterSendEvent = $event;
         });
 
@@ -211,12 +212,12 @@ abstract class TransportTestCase extends \yii\tests\TestCase
         $client->baseUrl = 'http://php.net';
 
         $beforeSendUrls = [];
-        $client->on(Client::EVENT_BEFORE_SEND, function(RequestEvent $event) use (&$beforeSendUrls) {
+        $client->on(ClientEvent::BEFORE_SEND, function(RequestEvent $event) use (&$beforeSendUrls) {
             $beforeSendUrls[] = $event->request->getUri()->__toString();
         });
 
         $afterSendUrls = [];
-        $client->on(Client::EVENT_AFTER_SEND, function(RequestEvent $event) use (&$afterSendUrls) {
+        $client->on(ClientEvent::AFTER_SEND, function(RequestEvent $event) use (&$afterSendUrls) {
             $afterSendUrls[] = $event->request->getUri()->__toString();
         });
 
@@ -241,8 +242,8 @@ abstract class TransportTestCase extends \yii\tests\TestCase
     public function testInvalidUrl()
     {
         $client = $this->createClient();
-        $request = $client->get('http:/example.com');
-        $this->assertEquals('http:/example.com', $request->getUri()->__toString());
+        $request = $client->get('htp:/example.com');
+        $this->assertEquals('htp:/example.com', $request->getUri()->__toString());
 
         $this->expectException(\yii\httpclient\Exception::class);
         $request->send();


### PR DESCRIPTION
Pay attention to 3 things:

- In UrlEncodedFormatter and XmlFormatter, I have not found $charset property in Application object; so I have used 'UTF-8';
- In TrasportTestCase testInvalidUrl has been used an url starting such as 'http:/www.example.com', missing second slash; but now it seems that curl accepts it, so I have changed in 'htp:/www.example.com', to check the error;
- In XmlFormatterTest has been used assertEqualsWithoutLE that does not remove also "\n". I left a PR on yii-core (https://github.com/yiisoft/yii-core/pull/156) to fix it.